### PR TITLE
return appKey as soon as it is found. Close #1

### DIFF
--- a/src/ios/DBChooser.m
+++ b/src/ios/DBChooser.m
@@ -147,6 +147,7 @@
             if ([scheme hasPrefix:@"db-"]) {
                 if (!appKey) {
                     appKey = [scheme substringFromIndex:3]; // substring after "db-"
+                    return appKey;
                 } else {
                     NSAssert(NO, @"DBChooser: WARNING multiple Dropbox url schemes found in Info.plist. Please use the method -initWithAppKey: instead.");
                 }


### PR DESCRIPTION
When in the Info.plist there are multiple definition of the "db-xxxx" key, we will return the first one instead of asserting.
