### PR TITLE
Update plugin.xml to work with build.phonegap.com, Add Dropbox URL Scheme for iOS 9+ 

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -46,13 +46,15 @@
                     <array>
                         <string>$DROPBOX_APP_KEY</string>
                     </array>
-                    <key>LSApplicationQueriesSchemes</key>
-                    <array>
-                        <string>dbapi-1</string>
-                        <string>dbapi-3</string>
-                    </array>
                 </dict>
             </array>
+        </config-file>
+        
+         <config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
+          <array>
+            <string>dbapi-1</string>
+            <string>dbapi-3</string>
+          </array>
         </config-file>
 
         <!-- DropboxChooser plugin files -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
                     <string>$APP_ID</string>
                     <key>CFBundleURLSchemes</key>
                     <array>
-                        <string>db-$DROPBOX_APP_KEY</string>
+                        <string>$DROPBOX_APP_KEY</string>
                     </array>
                 </dict>
             </array>

--- a/plugin.xml
+++ b/plugin.xml
@@ -46,6 +46,11 @@
                     <array>
                         <string>$DROPBOX_APP_KEY</string>
                     </array>
+                    <key>LSApplicationQueriesSchemes</key>
+                    <array>
+                        <string>dbapi-1</string>
+                        <string>dbapi-3</string>
+                    </array>
                 </dict>
             </array>
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
                     <string>$APP_ID</string>
                     <key>CFBundleURLSchemes</key>
                     <array>
-                        <string>db-$DROPBOX_APP_KEY</string>
+                        <string>$DROPBOX_APP_KEY</string>
                     </array>
                 </dict>
             </array>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,9 @@
         <engine name="cordova" version=">=3.0.0" />
     </engines>
 
+    <preference name="APP_ID"/>
+    <preference name="DROPBOX_APP_KEY"/>
+    
     <!-- ios -->
     <platform name="ios">
         <feature name="DropboxChooser">

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
                     <string>$APP_ID</string>
                     <key>CFBundleURLSchemes</key>
                     <array>
-                        <string>$DROPBOX_APP_KEY</string>
+                        <string>db-$DROPBOX_APP_KEY</string>
                     </array>
                 </dict>
             </array>


### PR DESCRIPTION
- Add $DROPBOX_APP_KEY and $APP_KEY as preferences to plugin.xml to work with phonegap cloud builds.
- Add Dropbox URL Scheme to list of allowed schemes to *Info.plist for iOS 9  support.
